### PR TITLE
Fixes to install and on_boot scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ Trying to keep it simple as possible. Enjoy!
 
 ## Manual Steps
 TBD
+
+## Donations
+### [Buy Me a ~~Coffee~~ Beer](https://bmc.link/jphamdev)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,3 @@ Trying to keep it simple as possible. Enjoy!
 
 ## Manual Steps
 TBD
-
-## Donations
-### [Buy Me a ~~Coffee~~ Beer](https://bmc.link/jphamdev)

--- a/wpa_supplicant/0-att-bypass.sh
+++ b/wpa_supplicant/0-att-bypass.sh
@@ -6,6 +6,7 @@ if ! dpkg -l wpasupplicant | grep ii >/dev/null; then
     dpkg -i /data/wpa_supplicant/wpasupplicant_2.9*.deb
 fi
 
+
 DATA_WPASUPPLICANT_DIR=/data/wpa_supplicant
 
 WPASUPPLICANT_CONF_DIR=/etc/wpa_supplicant/conf

--- a/wpa_supplicant/0-att-bypass.sh
+++ b/wpa_supplicant/0-att-bypass.sh
@@ -50,7 +50,7 @@ if [ ! -d "$WPASUPPLICANT_SERVICE_DIR" ]; then
 fi
 
 if [ ! -f "$OVERRIDE_CONF" ]; then
-    if /sbin/ethtool eth8 | grep -q "Link detected: yes"; then
+    if /sbin/ethtool eth8 | grep -q "Link detected:"; then
         cp ${DATA_WPASUPPLICANT_DIR}/override_UDMPro_UDMProSE.conf ${DATA_WPASUPPLICANT_DIR}/override.conf
         cp ${DATA_WPASUPPLICANT_DIR}/override_UDMPro_UDMProSE.conf ${OVERRIDE_CONF}
     else

--- a/wpa_supplicant/0-att-bypass.sh
+++ b/wpa_supplicant/0-att-bypass.sh
@@ -6,6 +6,7 @@ if ! dpkg -l wpasupplicant | grep ii >/dev/null; then
     dpkg -i /data/wpa_supplicant/wpasupplicant_2.9*.deb
 fi
 
+DATA_WPASUPPLICANT_DIR=/data/wpa_supplicant
 
 WPASUPPLICANT_CONF_DIR=/etc/wpa_supplicant/conf
 CA_PEM=${WPASUPPLICANT_CONF_DIR}/CA.pem

--- a/wpa_supplicant/0-att-bypass.sh
+++ b/wpa_supplicant/0-att-bypass.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 # This script installs wpa_supplicant if it's not installed.
 
-if ! dpkg -l wpa_supplicant | grep ii >/dev/null; then
+if ! dpkg -l wpasupplicant | grep ii >/dev/null; then
     dpkg -i /data/wpa_supplicant/libreadline8*.deb
     dpkg -i /data/wpa_supplicant/wpasupplicant_2.9*.deb
 fi
 
 
 WPASUPPLICANT_CONF_DIR=/etc/wpa_supplicant/conf
-CA_PEM=${WPASUPPLICANT_CONF_DIR}/CA.PEM
+CA_PEM=${WPASUPPLICANT_CONF_DIR}/CA.pem
 CLIENT_PEM=${WPASUPPLICANT_CONF_DIR}/Client.pem
 PRIVATEKEY_PEM=${WPASUPPLICANT_CONF_DIR}/PrivateKey.pem
 WPASUPPLICANT_CONF=${WPASUPPLICANT_CONF_DIR}/wpa_supplicant.conf

--- a/wpa_supplicant/install.sh
+++ b/wpa_supplicant/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script installs wpa_supplicant the first time.
 
-if ! dpkg -l wpa_supplicant | grep ii >/dev/null; then
+if ! dpkg -l wpasupplicant | grep ii >/dev/null; then
     dpkg -i /data/wpa_supplicant/libreadline8*.deb
     dpkg -i /data/wpa_supplicant/wpasupplicant_2.9*.deb
 fi
@@ -10,7 +10,7 @@ fi
 DATA_WPASUPPLICANT_DIR=/data/wpa_supplicant
 
 WPASUPPLICANT_CONF_DIR=/etc/wpa_supplicant/conf
-CA_PEM=${WPASUPPLICANT_CONF_DIR}/CA.PEM
+CA_PEM=${WPASUPPLICANT_CONF_DIR}/CA.pem
 CLIENT_PEM=${WPASUPPLICANT_CONF_DIR}/Client.pem
 PRIVATEKEY_PEM=${WPASUPPLICANT_CONF_DIR}/PrivateKey.pem
 WPASUPPLICANT_CONF=${WPASUPPLICANT_CONF_DIR}/wpa_supplicant.conf

--- a/wpa_supplicant/install.sh
+++ b/wpa_supplicant/install.sh
@@ -51,7 +51,7 @@ if [ ! -d "$WPASUPPLICANT_SERVICE_DIR" ]; then
 fi
 
 if [ ! -f "$OVERRIDE_CONF" ]; then
-    if /sbin/ethtool eth8 | grep -q "Link detected: yes"; then
+    if /sbin/ethtool eth8 | grep -q "Link detected:"; then
         cp ${DATA_WPASUPPLICANT_DIR}/override_UDMPro_UDMProSE.conf ${DATA_WPASUPPLICANT_DIR}/override.conf
         cp ${DATA_WPASUPPLICANT_DIR}/override_UDMPro_UDMProSE.conf ${OVERRIDE_CONF}
     else


### PR DESCRIPTION
Have been using the wpa_supplicant bypass for years, across UDM-Pro versions 1.x, 2.x, and 3.x. But with 2.x and 3.x, I've always had to manually reinstall after updates. Today, I used the script to see if I could get my bypass to persist across the new fiirmware update on my UDM-Pro. It didn't work, and I uncovered a few reasons why. 

I think that the specific errors I ran into wouldn't have been obvious if someone applied this script from a pre-existing installation that was already "compliant". But my old wpa_supplicant instance used files in /etc/wpa_supplicant/, not in /etc/wpa_supplicant/config/, so things weren't already in the "right" place and I ran into the issue with the file extension case in CA.PEM. I also noticed it was trying to install the wpasupplicant package when it didn't need to. And that's because in the dpkg/apt list, its installed name has no underscore.

I barely know how to use github, so I hope I'm contributing right. I hope you can see the comments I attached to each commit to explain the code changes. If you have questions, I'm happy to answer.